### PR TITLE
Resolving Xcode 6.3 warnings regarding auto property synthesis of proper...

### DIFF
--- a/iOS/iPadDemoApp/pubnub/libs/PubNub/Network/Packets/PNLeaveRequest.m
+++ b/iOS/iPadDemoApp/pubnub/libs/PubNub/Network/Packets/PNLeaveRequest.m
@@ -39,10 +39,6 @@
 // be closed before sending this message or not
 @property (nonatomic, assign, getter = shouldCloseConnection) BOOL closeConnection;
 
-// Stores whether leave request was sent to subscribe
-// on new channels or as result of user request
-@property (nonatomic, assign, getter = isSendingByUserRequest) BOOL sendingByUserRequest;
-
 /**
  Storing configuration dependant parameters
  */

--- a/iOS/iPadDemoApp/pubnub/libs/PubNub/Network/Packets/PNSubscribeRequest.m
+++ b/iOS/iPadDemoApp/pubnub/libs/PubNub/Network/Packets/PNSubscribeRequest.m
@@ -54,9 +54,6 @@
  */
 @property (nonatomic, strong) NSDictionary *state;
 
-// Stores whether leave request was sent to subscribe on new channels or as result of user request
-@property (nonatomic, assign, getter = isSendingByUserRequest) BOOL sendingByUserRequest;
-
 @property (nonatomic, assign, getter = isPerformingMultipleActions) BOOL performingMultipleActions;
 
 @property (nonatomic, assign) NSInteger presenceHeartbeatTimeout;


### PR DESCRIPTION
...ties implemented by a superclass.

Minor: Updates to address Xcode 6.3 warnings
