### PR TITLE
[NO-QA][DRG-118991] Add updateAuthKey method

### DIFF
--- a/PubNub/Core/PubNub+Core.h
+++ b/PubNub/Core/PubNub+Core.h
@@ -182,6 +182,11 @@ configuration.TLSEnabled = NO;
                 callbackQueue:(nullable dispatch_queue_t)callbackQueue
                    completion:(void(^)(PubNub *client))block;
 
+/* This will update the pubnub authkey that was required after the AccessManager V3 upgrade.
+ In Access Manager v3, adding channels to existing tokens(authKey) is no longer possible. 
+ Instead, we need to obtain a new token each time a user is added to a new channel.*/
+
+- (void)updateAuthKey:(NSString *)authKey;
 #pragma mark -
 
 

--- a/PubNub/Core/PubNub+Core.m
+++ b/PubNub/Core/PubNub+Core.m
@@ -343,6 +343,10 @@ NS_ASSUME_NONNULL_END
     }
 }
 
+- (void)updateAuthKey:(NSString *)authKey
+{
+    self.configuration.authKey = authKey;
+}
 
 #pragma mark - Fabric support
 #ifdef FABRIC_SUPPORT


### PR DESCRIPTION
To compliance with PubNub guidelines, we need to Upgrade PubNub AccessManager to V3

With upgrading the PubNub authentication method from PAM V2 to Access Manager V3, adding channels to existing tokens is no longer possible. Instead, we need to obtain a new token each time a user is added to a new channel.

Create a new method to update authKey
**- (void)updateAuthKey:(NSString *)authKey**